### PR TITLE
修复墙上告示牌复制bug

### DIFF
--- a/src/main/java/pers/solid/mishang/uc/item/TextCopyToolItem.java
+++ b/src/main/java/pers/solid/mishang/uc/item/TextCopyToolItem.java
@@ -272,7 +272,7 @@ public class TextCopyToolItem extends BlockToolItem implements ItemResourceGener
         texts.add(textContext.createNbt());
       }
       stack.setSubNbt("texts", texts);
-      stack.setSubNbt("fromVanillaSign", NbtByte.of(true));
+      stack.setSubNbt("fromVanillaSign", NbtByte.of(false));
       player.sendMessage(TextBridge.translatable("item.mishanguc.text_copy_tool.message.success.copy", texts.size()), true);
       return ActionResult.SUCCESS;
     } else {


### PR DESCRIPTION
使用文本复制工具复制墙上告示牌时，告示牌上的文本被误标为vanilla，导致文本Y坐标被重置。

Text copy tool erroneously labels texts copied from modded wall signs as vanilla, causing them to be rearranged on the Y-axis when pasted.